### PR TITLE
fix: eliminate empty space on right side with fixed 4-column grid

### DIFF
--- a/src/pages/Profile/InstagramAnalytics.js
+++ b/src/pages/Profile/InstagramAnalytics.js
@@ -472,8 +472,8 @@ const InstagramAnalytics = () => {
                   <Box sx={{ flex: 1 }}>
                     <Box sx={{ 
                       display: 'grid', 
-                      gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', 
-                      gap: 2,
+                      gridTemplateColumns: 'repeat(4, 1fr)', 
+                      gap: 1.5,
                       width: '100%'
                     }}>
                       {getAnalyticsCards(selectedAccountData).map((card, index) => (
@@ -495,7 +495,7 @@ const InstagramAnalytics = () => {
                         >
                           <CardContent sx={{ 
                             textAlign: "center", 
-                            p: 2, 
+                            p: 1.5, 
                             height: '100%', 
                             display: 'flex', 
                             flexDirection: 'column', 
@@ -505,9 +505,9 @@ const InstagramAnalytics = () => {
                             <Typography 
                               variant="h4" 
                               sx={{ 
-                                fontSize: '1.5rem', 
+                                fontSize: '1.4rem', 
                                 fontWeight: 700, 
-                                mb: 1,
+                                mb: 0.5,
                                 color: '#1976d2',
                                 letterSpacing: '-0.5px'
                               }}
@@ -517,10 +517,11 @@ const InstagramAnalytics = () => {
                             <Typography 
                               variant="body2" 
                               sx={{ 
-                                fontSize: '0.85rem', 
+                                fontSize: '0.75rem', 
                                 color: 'text.secondary',
                                 fontWeight: 500,
-                                textAlign: 'center'
+                                textAlign: 'center',
+                                lineHeight: 1.2
                               }}
                             >
                               {card.label}


### PR DESCRIPTION
- Change grid layout from auto-fit to fixed 4 columns (repeat(4, 1fr))
- This ensures analytics cards fill the entire available width
- Adjust typography sizing to fit better in fixed columns:
  - Reduce value font size from 1.5rem to 1.4rem
  - Reduce label font size from 0.85rem to 0.75rem
  - Reduce padding from 2 to 1.5 and margin from 1 to 0.5
- Reduce gap from 2 to 1.5 for better spacing
- Add lineHeight: 1.2 for better text readability in smaller cards
- Now displays 3 rows of 4 cards each, filling the full width