### PR TITLE
Generate collaboration agreement contract

### DIFF
--- a/src/pages/Contract/AIContractGenerator.js
+++ b/src/pages/Contract/AIContractGenerator.js
@@ -209,7 +209,10 @@ const AIContractGenerator = ({ onBack = null }) => {
       const data = await response.json();
       
       // Updated to handle the new API response structure
-      if (data.success && data.ai_log && data.ai_log.generated_content) {
+      if (data.success && data.contract_content) {
+        setGeneratedContract(data.contract_content);
+        setShowContractContent(true);
+      } else if (data.success && data.ai_log && data.ai_log.generated_content) {
         setGeneratedContract(data.ai_log.generated_content);
         setShowContractContent(true);
       } else {


### PR DESCRIPTION
Update contract generation to display `contract_content` from the API response.

The previous implementation expected `generated_content` within `ai_log`, but the API now returns the contract directly in `contract_content`. This change ensures the generated contract is correctly displayed in the preview section.