### PR TITLE
Restore sidebar and link to /link

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -206,7 +206,16 @@ const Sidebar = () => {
           </ListItemButton>
         </ListItem>
 
-
+        <ListItem disablePadding>
+          <ListItemButton sx={{ display: 'flex', justifyContent: 'center' }}>
+            <Link to="/link">
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', color: '#cbaef7' }}>
+                <LanguageIcon fontSize="medium" />
+                <Typography variant="body2" sx={{ fontSize: '12px', whiteSpace: 'nowrap' }}>Link</Typography>
+              </Box>
+            </Link>
+          </ListItemButton>
+        </ListItem>
 
         {/* Dynamic Marketplace Options Based on Role */}
         {marketplaceOptions.map((option, index) => (


### PR DESCRIPTION
Add 'Link' item to the sidebar to restore navigation to the `/link` page.

---

[Open in Web](https://cursor.com/agents?id=bc-ba69e0ba-7b18-4c24-b305-a51cb1a9b19f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ba69e0ba-7b18-4c24-b305-a51cb1a9b19f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)