### PR TITLE
Fix loadUserUrls initialization error

### DIFF
--- a/src/pages/Link/ShortLinkPage.js
+++ b/src/pages/Link/ShortLinkPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Typography,
@@ -73,14 +73,15 @@ const ShortLinkPage = () => {
   const [analyticsDialog, setAnalyticsDialog] = useState({ open: false, url: null });
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
 
-  // Load user's URLs on component mount
-  useEffect(() => {
-    if (user?.id) {
-      loadUserUrls();
-    }
-  }, [user, loadUserUrls]);
+  const showSnackbar = useCallback((message, severity = 'success') => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
 
-  const loadUserUrls = async () => {
+  const handleCloseSnackbar = useCallback(() => {
+    setSnackbar(prev => ({ ...prev, open: false }));
+  }, []);
+
+  const loadUserUrls = useCallback(async () => {
     try {
       setLoadingUrls(true);
       const response = await getUserUrls(user.id);
@@ -95,7 +96,14 @@ const ShortLinkPage = () => {
     } finally {
       setLoadingUrls(false);
     }
-  };
+  }, [user?.id, showSnackbar]);
+
+  // Load user's URLs on component mount
+  useEffect(() => {
+    if (user?.id) {
+      loadUserUrls();
+    }
+  }, [user, loadUserUrls]);
 
   const handleSwitchToLink = () => {
     navigate('/link-advanced');
@@ -191,13 +199,8 @@ const ShortLinkPage = () => {
     setAnalyticsDialog({ open: true, url });
   };
 
-  const showSnackbar = (message, severity = 'success') => {
-    setSnackbar({ open: true, message, severity });
-  };
 
-  const handleCloseSnackbar = () => {
-    setSnackbar({ ...snackbar, open: false });
-  };
+
 
   return (
     <Layout>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor function definitions in `ShortLinkPage.js` to fix 'Cannot access before initialization' runtime error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error occurred because `const` declared functions like `loadUserUrls` were referenced in `useEffect` dependencies before their definition, creating a temporal dead zone. Wrapping these functions with `useCallback` and reordering them ensures they are properly initialized and memoized.

---

[Open in Web](https://cursor.com/agents?id=bc-67a95612-b6d5-48e9-956d-d7dbec39628e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-67a95612-b6d5-48e9-956d-d7dbec39628e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)