### PR TITLE
Implement sidebar link switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import MarketplaceModule from './pages/MarketPlace/MarketplaceModule';
 import MarketplacePostDetail from './pages/MarketPlace/MarketplacePostDetail';
 import MarketplaceStatistics from './pages/MarketPlace/MarketplaceStatistics';
 import SettingPage from './pages/Setting/SettingPage';
-import ShortLinkPage from './pages/Link/ShortLinkPage';
+import LinkPage from './pages/Link/LinkPage';
 import LinkAdvancedPage from './pages/Link/LinkAdvancedPage';
 
 // Component that renders routes based on user role
@@ -210,7 +210,7 @@ const AppRoutes = () => {
 
       <Route path="/link" element={
         <ProtectedRoute>
-          <ShortLinkPage />
+          <LinkPage />
         </ProtectedRoute>
       } />
 

--- a/src/pages/Link/LinkPage.js
+++ b/src/pages/Link/LinkPage.js
@@ -1,15 +1,32 @@
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
+import { Container } from '@mui/material';
+import Layout from '../../components/Layout';
+import TabComponent from '../../components/TabComponent';
+
+// Import the original components
+import ShortLinkPage from './ShortLinkPage';
+import LinkAdvancedPage from './LinkAdvancedPage';
 
 const LinkPage = () => {
-  const navigate = useNavigate();
+  // Create tab configuration for the switcher
+  const tabs = [
+    {
+      label: 'ShortLink',
+      content: <ShortLinkPage noLayout={true} />
+    },
+    {
+      label: 'Link Advanced', 
+      content: <LinkAdvancedPage />
+    }
+  ];
 
-  useEffect(() => {
-    // Redirect to ShortLinkPage by default for backward compatibility
-    navigate('/link', { replace: true });
-  }, [navigate]);
-
-  return null; // This component just redirects
+  return (
+    <Layout>
+      <Container maxWidth="xl" sx={{ py: 3 }}>
+        <TabComponent tabs={tabs} defaultIndex={0} />
+      </Container>
+    </Layout>
+  );
 };
 
 export default LinkPage;

--- a/src/pages/Link/ShortLinkPage.js
+++ b/src/pages/Link/ShortLinkPage.js
@@ -58,7 +58,7 @@ import {
   generateQRCodeUrl
 } from '../../services/urlShortenerApi';
 
-const ShortLinkPage = () => {
+const ShortLinkPage = ({ noLayout = false }) => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [longUrl, setLongUrl] = useState('');
@@ -202,9 +202,8 @@ const ShortLinkPage = () => {
 
 
 
-  return (
-    <Layout>
-      <Box sx={{ flexGrow: 1, bgcolor: '#f5edf8', minHeight: '100vh' }}>
+  const content = (
+    <Box sx={{ flexGrow: 1, bgcolor: '#f5edf8', minHeight: '100vh' }}>
         {/* Header */}
         <Paper
           elevation={0}
@@ -638,8 +637,9 @@ const ShortLinkPage = () => {
           </Snackbar>
         </Container>
       </Box>
-    </Layout>
-  );
+    );
+
+  return noLayout ? content : <Layout>{content}</Layout>;
 };
 
 export default ShortLinkPage;


### PR DESCRIPTION
Introduce a Link page with a tab switcher for ShortLink and Link Advanced functionalities to unify link management under one sidebar entry.

The original `ShortLinkPage` included its own `Layout` wrapper, which would cause styling issues when embedded within the new `LinkPage` (which also provides a `Layout`). This PR modifies `ShortLinkPage` to accept a `noLayout` prop, allowing it to render its content directly when used inside `LinkPage`, ensuring consistent styling and preventing redundant wrappers.

---

[Open in Web](https://cursor.com/agents?id=bc-205c7d49-a001-4761-a942-2445a55ee94a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-205c7d49-a001-4761-a942-2445a55ee94a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)