### PR TITLE
Fix top nav bar positioning above switcher

### DIFF
--- a/src/pages/Link/ShortLinkPage.js
+++ b/src/pages/Link/ShortLinkPage.js
@@ -230,35 +230,38 @@ const ShortLinkPage = ({ noLayout = false }) => {
         </Paper>
 
         <Container maxWidth="xl" sx={{ py: 4 }}>
+          {/* Tab Switcher - moved outside of Card */}
+          <Box sx={{ mb: 3 }}>
+            <Tabs
+              value={0}
+              sx={{
+                bgcolor: '#fff',
+                borderRadius: 1,
+                boxShadow: 1,
+                '& .MuiTab-root': {
+                  textTransform: 'none',
+                  fontSize: '1rem',
+                  fontWeight: 'bold',
+                  minWidth: 120,
+                  color: '#666',
+                  '&.Mui-selected': {
+                    color: '#1976d2',
+                  }
+                },
+                '& .MuiTabs-indicator': {
+                  backgroundColor: '#1976d2',
+                  height: 3,
+                }
+              }}
+            >
+              <Tab label="Short Link" />
+              <Tab label="Link" onClick={handleSwitchToLink} />
+            </Tabs>
+          </Box>
+
           {/* URL Generator Section */}
           <Card sx={{ mb: 4, boxShadow: 3 }}>
             <CardContent sx={{ p: 4 }}>
-              {/* Tab Switcher */}
-              <Box sx={{ mb: 3 }}>
-                <Tabs
-                  value={0}
-                  sx={{
-                    '& .MuiTab-root': {
-                      textTransform: 'none',
-                      fontSize: '1rem',
-                      fontWeight: 'bold',
-                      minWidth: 120,
-                      color: '#666',
-                      '&.Mui-selected': {
-                        color: '#1976d2',
-                      }
-                    },
-                    '& .MuiTabs-indicator': {
-                      backgroundColor: '#1976d2',
-                      height: 3,
-                    }
-                  }}
-                >
-                  <Tab label="Short Link" />
-                  <Tab label="Link" onClick={handleSwitchToLink} />
-                </Tabs>
-              </Box>
-
               <Typography variant="h5" sx={{ mb: 3, fontWeight: 'bold', color: '#1976d2' }}>
                 🔗 Create Short URL
               </Typography>


### PR DESCRIPTION
<!-- Reposition the tab switcher in `ShortLinkPage` to appear above the main content card. -->
The tab switcher was previously rendered inside the main content card, causing it to appear inconsistent with other module layouts where tabs are positioned between the page header and the main content. This change repositions the tabs for a consistent UI.

---

[Open in Web](https://cursor.com/agents?id=bc-48bfd46a-9a71-494b-bbb1-7611f71e30a3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-48bfd46a-9a71-494b-bbb1-7611f71e30a3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)