### PR TITLE
Move top bar above switcher

### DIFF
--- a/src/pages/Link/ShortLinkPage.js
+++ b/src/pages/Link/ShortLinkPage.js
@@ -204,33 +204,34 @@ const ShortLinkPage = ({ noLayout = false }) => {
 
   const content = (
     <Box sx={{ flexGrow: 1, bgcolor: '#f5edf8', minHeight: '100vh' }}>
-        {/* Header */}
-        <Paper
-          elevation={0}
-          sx={{
-            p: 2,
-            backgroundColor: '#091a48',
-            borderRadius: 0,
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center'
-          }}
-        >
-          <Typography variant="h6" sx={{ color: '#fff' }}>
-            URL Shortener Dashboard
-          </Typography>
-          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-            <IconButton size="large" sx={{ color: 'white' }}>
-              <NotificationsIcon />
-            </IconButton>
-            <IconButton size="large" sx={{ color: 'white' }}>
-              <AccountCircleIcon />
-            </IconButton>
-          </Box>
-        </Paper>
-
         <Container maxWidth="xl" sx={{ py: 4 }}>
-          {/* Tab Switcher - moved outside of Card */}
+          {/* Header - moved above tab switcher */}
+          <Paper
+            elevation={0}
+            sx={{
+              p: 2,
+              backgroundColor: '#091a48',
+              borderRadius: 1,
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              mb: 3
+            }}
+          >
+            <Typography variant="h6" sx={{ color: '#fff' }}>
+              URL Shortener Dashboard
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              <IconButton size="large" sx={{ color: 'white' }}>
+                <NotificationsIcon />
+              </IconButton>
+              <IconButton size="large" sx={{ color: 'white' }}>
+                <AccountCircleIcon />
+              </IconButton>
+            </Box>
+          </Paper>
+
+          {/* Tab Switcher */}
           <Box sx={{ mb: 3 }}>
             <Tabs
               value={0}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move the "URL Shortener Dashboard" header above the tab switcher to match the requested layout.

---

[Open in Web](https://cursor.com/agents?id=bc-2d7db335-b394-444b-b09d-5c5182f797e9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2d7db335-b394-444b-b09d-5c5182f797e9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)