### PR TITLE
Implement sidebar tab toggler functionality

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -38,7 +38,6 @@ import PersonIcon from '@mui/icons-material/Person';
 import { Link, useNavigate } from "react-router-dom";
 import LanguageIcon from '@mui/icons-material/Language';
 import { useAuth } from "../authContext/AuthContext";
-import LinkModal from './LinkModal';
 
 const footerItems = [
   { icon: <MessageSquareIcon />, active: true },
@@ -49,7 +48,6 @@ const Sidebar = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [, forceUpdate] = useState({});
-  const [linkModalOpen, setLinkModalOpen] = useState(false);
 
   // Force re-render when user changes
   useEffect(() => {
@@ -209,14 +207,13 @@ const Sidebar = () => {
         </ListItem>
 
         <ListItem disablePadding>
-          <ListItemButton 
-            sx={{ display: 'flex', justifyContent: 'center' }}
-            onClick={() => setLinkModalOpen(true)}
-          >
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', color: '#cbaef7' }}>
-              <LanguageIcon fontSize="medium" />
-              <Typography variant="body2" sx={{ fontSize: '12px', whiteSpace: 'nowrap' }}>Link</Typography>
-            </Box>
+          <ListItemButton sx={{ display: 'flex', justifyContent: 'center' }}>
+            <Link to="/link">
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', color: '#cbaef7' }}>
+                <LanguageIcon fontSize="medium" />
+                <Typography variant="body2" sx={{ fontSize: '12px', whiteSpace: 'nowrap' }}>Link</Typography>
+              </Box>
+            </Link>
           </ListItemButton>
         </ListItem>
 
@@ -275,12 +272,6 @@ const Sidebar = () => {
 
         
       </Box>
-      
-      {/* Link Modal */}
-      <LinkModal 
-        open={linkModalOpen} 
-        onClose={() => setLinkModalOpen(false)} 
-      />
     </Box>
   );
 };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Change sidebar 'Link' item to navigate to the LinkPage with tab toggler instead of opening a modal.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This restores the user's preferred tabbed interface for link management, replacing the unwanted modal dialog.

---
<a href="https://cursor.com/background-agent?bcId=bc-af9b00ae-dab8-4fa3-924d-25f03eac03d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af9b00ae-dab8-4fa3-924d-25f03eac03d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>