### PR TITLE
Debug marketplace module reference error

### DIFF
--- a/src/pages/MarketPlace/MarketplaceModule.js
+++ b/src/pages/MarketPlace/MarketplaceModule.js
@@ -106,36 +106,21 @@ const MarketplaceModule = () => {
   //   inputRef.current?.focus();
   // }, []);
 
-  // Debounced search effect
-  useEffect(() => {
-    const debounceTimer = setTimeout(() => {
-      setCurrentPage(1); // Reset to first page when searching
-      loadMarketplacePosts();
-    }, 300);
-
-    return () => clearTimeout(debounceTimer);
-  }, [searchQuery, statusFilter, typeFilter, categoryFilter, targetAudienceFilter, loadMarketplacePosts]);
-
-  useEffect(() => {
-    // Update view when route changes
-    setCurrentView(getCurrentView());
-    setCurrentMode(getCurrentMode());
-    setCurrentPage(1);
-    loadMarketplacePosts();
-    loadStatistics();
-  }, [location.pathname, loadMarketplacePosts, loadStatistics, getCurrentView, getCurrentMode]);
-
   // Load posts when page changes
   useEffect(() => {
-    loadMarketplacePosts();
-  }, [currentPage, loadMarketplacePosts]);
+    if (typeof loadMarketplacePosts === 'function') {
+      loadMarketplacePosts();
+    }
+  }, [currentPage]);
 
   // Load bids when influencer switches to bids view
   useEffect(() => {
     if (currentMode === 'influencer' && influencerView === 'bids') {
-      loadMyBids();
+      if (typeof loadMyBids === 'function') {
+        loadMyBids();
+      }
     }
-  }, [influencerView, currentMode, loadMyBids]);
+  }, [influencerView, currentMode]);
 
   // Redirect based on user role (only for non-admin users accessing wrong routes)
   useEffect(() => {
@@ -368,6 +353,26 @@ const MarketplaceModule = () => {
       // Statistics are optional, don't show error to user
     }
   }, []);
+
+  // Debounced search effect - placed after function definitions
+  useEffect(() => {
+    const debounceTimer = setTimeout(() => {
+      setCurrentPage(1); // Reset to first page when searching
+      loadMarketplacePosts();
+    }, 300);
+
+    return () => clearTimeout(debounceTimer);
+  }, [searchQuery, statusFilter, typeFilter, categoryFilter, targetAudienceFilter, loadMarketplacePosts]);
+
+  // Route change effect - placed after function definitions
+  useEffect(() => {
+    // Update view when route changes
+    setCurrentView(getCurrentView());
+    setCurrentMode(getCurrentMode());
+    setCurrentPage(1);
+    loadMarketplacePosts();
+    loadStatistics();
+  }, [location.pathname, loadMarketplacePosts, loadStatistics, getCurrentView, getCurrentMode]);
 
   const handleEditDirect = (post) => {
     navigate('/brand/marketplace/new', { state: { editPost: post } });


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix "Cannot access 'fe' before initialization" error by reordering `useEffect` hooks and adding safety checks.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error was caused by `useEffect` hooks attempting to use callback functions (`loadMarketplacePosts`, `loadMyBids`, `loadStatistics`) before they were defined, leading to a circular dependency and temporal dead zone. Moving these `useEffect` hooks after their respective function definitions and adding `typeof` checks resolves this issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-b219699c-75d3-442d-a44d-7b189af2140c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b219699c-75d3-442d-a44d-7b189af2140c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>